### PR TITLE
Add demo CTA to $2,499 tier + link FAQ call text (fixes #23)

### DIFF
--- a/agents.html
+++ b/agents.html
@@ -480,6 +480,7 @@
         </ul>
         <div class="pricing-tier__cta">
           <a href="/buy/team" class="btn btn--gold btn--lg">Get Your Full Team — $2,499</a>
+          <a href="/demo" class="btn btn--ghost" style="margin-top: var(--sp-2); display: inline-block;">Or request a free demo first</a>
         </div>
       </div>
     </div>
@@ -569,7 +570,7 @@
       <button class="faq__question" aria-expanded="false" aria-controls="faq-6">"Can I see this working before I buy?"</button>
       <div class="faq__answer" id="faq-6" aria-hidden="true">
         <div class="faq__answer-inner">
-          <p>You're looking at it. This website, our email outreach, our social media, our prospecting -- it's all run by the same agents we'd build for you. Book a 30-minute call and we'll show you exactly how our agents work, live.</p>
+          <p>You're looking at it. This website, our email outreach, our social media, our prospecting -- it's all run by the same agents we'd build for you. <a href="/demo" style="color: var(--gold-text); text-decoration: underline;">Book a 30-minute call</a> and we'll show you exactly how our agents work, live.</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## What this fixes

The $2,499 Agent Team tier on /agents goes straight to Stripe checkout with no softer alternative. Visitors who aren't ready to drop $2,499 without talking to someone have no path forward — they bounce.

## Changes (2 lines)

1. **Added secondary demo CTA** under the $2,499 buy button:
   ```html
   <a href="/demo" class="btn btn--ghost" style="margin-top: var(--sp-2); display: inline-block;">Or request a free demo first</a>
   ```

2. **Linked FAQ "30-minute call" text** in the "Can I see this working before I buy?" answer to /demo:
   ```html
   <a href="/demo" style="color: var(--gold-text); text-decoration: underline;">Book a 30-minute call</a>
   ```

## Why it matters

- $2,499 is a high-trust purchase. Giving people a softer on-ramp (demo) before asking for money reduces bounce
- The FAQ already mentions booking a call but the text was unlinked — dead end
- Uses existing design system classes (btn--ghost) so it fits the Blueprint style

Closes #23